### PR TITLE
Basic preprocessor

### DIFF
--- a/cd_preproc.c
+++ b/cd_preproc.c
@@ -1,0 +1,2 @@
+#define CD_PREPROC_IMPLEMENTATION
+#include "cd_preproc.h"

--- a/cd_preproc.h
+++ b/cd_preproc.h
@@ -15,12 +15,18 @@ typedef enum {
     CD_PP_LOGLEVEL_ERROR
 } cd_pp_loglevel_t;
 
-typedef void (*cd_pp_log_func_t)(void* log_data, cd_pp_loglevel_t level, const char* msg, ...);
-
 typedef struct {
     const char* begin;
     const char* end;
 } cd_pp_strview_t;
+
+typedef struct cd_pp_state_t cd_pp_state_t;
+typedef struct cd_pp_str_item_t cd_pp_str_item_t;
+
+typedef void (*cd_pp_log_func_t)(void* log_data, cd_pp_loglevel_t level, const char* msg, ...);
+typedef bool (*cd_pp_output_func_t)(void* output_data, cd_pp_strview_t output);
+typedef bool (*cd_pp_handle_include_t)(void* handler_data, cd_pp_state_t* state, cd_pp_strview_t path);
+
 
 typedef struct {
     size_t*             keys;
@@ -36,28 +42,28 @@ typedef struct {
     size_t              capacity;
 } cd_pp_arena_t;
 
-typedef struct cd_pp_str_item_t cd_pp_str_item_t;
 struct cd_pp_str_item_t {
     cd_pp_str_item_t*   next;
     size_t              length;
     char                str[0];
 };
 
-typedef struct {
-    cd_pp_log_func_t    log_func;
-    void*               log_data;
-    cd_pp_map_t         str_map;
-    cd_pp_arena_t       str_mem;
-} cd_pp_state_t;
+struct cd_pp_state_t {
+    cd_pp_log_func_t        log_func;
+    void*                   log_data;
+    cd_pp_output_func_t     output_func;
+    void*                   output_data;
+    cd_pp_handle_include_t  handle_include;
+    void*                   handle_data;
+    cd_pp_map_t             str_map;
+    cd_pp_arena_t           str_mem;
+};
 
-typedef bool (*cd_pp_handle_include_t)(void* handler_data, cd_pp_state_t* state, cd_pp_strview_t path);
 
 const char* cd_pp_str_intern(cd_pp_state_t* state, cd_pp_strview_t str);
 
 bool cd_pp_process(cd_pp_state_t*           state,
-                   cd_pp_strview_t          input,
-                   cd_pp_handle_include_t   handle_include,
-                   void*                    handle_data);
+                   cd_pp_strview_t          input);
 
 void cd_pp_state_free(cd_pp_state_t* state);
 

--- a/cd_preproc.h
+++ b/cd_preproc.h
@@ -1,0 +1,244 @@
+#ifndef CD_PREPROC_H
+#define CD_PREPROC_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+    CD_PP_LOGLEVEL_DEBUG,
+    CD_PP_LOGLEVEL_WARNING,
+    CD_PP_LOGLEVEL_ERROR
+} cd_pp_loglevel_t;
+
+typedef void (*cd_pp_log_func_t)(void* log_data, cd_pp_loglevel_t level, const char* msg);
+
+typedef struct {
+    size_t*             keys;
+    size_t*             vals;
+    size_t              fill;
+    size_t              capacity;
+} cd_pp_map_t;
+
+typedef struct {
+    uint8_t*            first;
+    uint8_t*            curr;
+    size_t              fill;
+    size_t              capacity;
+} cd_pp_arena_t;
+
+typedef struct cd_pp_str_item_t cd_pp_str_item_t;
+struct cd_pp_str_item_t {
+    cd_pp_str_item_t*   next;
+    size_t              length;
+    char                str[0];
+};
+
+typedef struct {
+    cd_pp_log_func_t    log_func;
+    void*               log_data;
+    cd_pp_map_t         str_map;
+    cd_pp_arena_t       str_mem;
+} cd_pp_state_t;
+
+const char* cd_pp_str_intern(cd_pp_state_t* state, const char* begin, const char* end);
+
+void cd_pp_state_free(cd_pp_state_t* state);
+
+#ifdef CD_PREPROC_IMPLEMENTATION
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdlib.h>
+
+void* cd_pp_malloc(size_t size)
+{
+    void* rv = malloc(size);
+    assert(rv != NULL);
+    return rv;
+}
+
+void* cd_pp_calloc(size_t num, size_t size)
+{
+    void* rv = calloc(num, size);
+    assert(rv != NULL);
+    return rv;
+}
+
+void* cd_pp_arena_alloc(cd_pp_state_t* state, cd_pp_arena_t* arena, size_t bytes)
+{
+    if(bytes == 0) return NULL;
+    
+    size_t padded = (bytes + sizeof(void*) - 1) & ~(sizeof(void*));
+    if(arena->capacity < arena->fill + padded) {
+        const size_t page_size = 1024;
+        arena->fill = sizeof(uint8_t*);
+        arena->capacity = (arena->fill + padded) < page_size ? page_size : (arena->fill + padded);
+        
+        uint8_t* page = cd_pp_malloc(arena->capacity);
+        *((uint8_t**)page) = NULL;
+        if(arena->first == NULL) {
+            arena->first = page;
+            arena->curr = page;
+        }
+        else {
+            *(uint8_t**)arena->curr = page;
+            arena->curr = page;
+        }
+    }
+    
+    assert(arena->first);
+    assert(arena->curr);
+    assert(arena->fill + padded <= arena->capacity);
+    
+    void* rv = arena->curr + arena->fill;
+    arena->fill += padded;
+    return rv;
+}
+
+void cd_pp_arena_free(cd_pp_arena_t* arena)
+{
+    uint8_t* page = arena->first;
+    while(page != NULL) {
+        uint8_t* next = *(uint8_t**)page;
+        free(page);
+        page = next;
+    }
+    *arena = (cd_pp_arena_t){0};
+}
+
+size_t cd_pp_hash_size_t(size_t value)
+{
+    value *= 0xff51afd7ed558ccd;
+    value ^= value >> 32;
+    return value;
+}
+
+size_t cd_pp_map_get(const cd_pp_map_t* map, size_t key)
+{
+    assert(key != 0);
+    if(map->fill == 0) return 0;
+    
+    size_t mask = map->capacity-1;
+    for(size_t i=cd_pp_hash_size_t(key); true; i++) {
+        i = i & mask;
+        if(map->keys[i] == key) {
+            return map->vals[i];
+        }
+        else if(map->keys[i] == 0) {
+            return 0;
+        }
+    }
+}
+
+void cd_pp_map_insert(cd_pp_map_t* map, size_t key, size_t val)
+{
+    assert(key != 0);                       // 0 is used to tag empty
+    assert(val != 0);                       // zero val is used for not found
+    if(map->capacity <= 2 * map->fill) {    // Resize and rehash
+        size_t old_capacity = map->capacity;
+        size_t* old_keys = map->keys;
+        size_t* old_vals = map->vals;
+        map->fill = 0;
+        map->capacity = map->capacity ? 2 * map->capacity : 16;
+        assert((map->capacity & (map->capacity-1)) == 0);
+        map->keys = (size_t*)cd_pp_calloc(map->capacity, sizeof(size_t));
+        map->vals = (size_t*)cd_pp_malloc(map->capacity * sizeof(size_t));
+        for(size_t i=0; i<old_capacity; i++) {
+            if(old_keys[i]) {
+                cd_pp_map_insert(map, old_keys[i], old_vals[i]);
+            }
+        }
+    }
+    size_t mask = map->capacity - 1;
+    for(size_t i=cd_pp_hash_size_t(key); true; i++) {
+        i = i & mask;
+        if(map->keys[i] == key) {
+            map->vals[i] = val;
+            break;
+        }
+        else if(map->keys[i] == 0) {
+            map->keys[i] = key;
+            map->vals[i] = val;
+            map->fill++;
+            break;
+        }
+    }
+}
+
+void cd_pp_map_free(cd_pp_map_t* map)
+{
+    free(map->keys);
+    free(map->vals);
+    *map = (cd_pp_map_t){0};
+}
+
+size_t cd_pp_fnv_1a(const char* begin, const char* end)
+{
+    assert(begin <= end);
+    if(sizeof(size_t) == sizeof(uint32_t)) {
+        uint32_t hash = 0x811c9dc5;
+        for (const char * p = begin; p < end; p++) {
+            hash = hash ^ *p;
+            hash = hash * 0x01000193;
+        }
+        return (size_t)hash;
+    }
+    else {
+        uint64_t hash = 0xcbf29ce484222325;
+        for (const char * p = begin; p < end; p++) {
+            hash = hash ^ *p;
+            hash = hash * 0x100000001B3;
+        }
+        return (size_t)hash;
+    }
+}
+
+const char* cd_pp_str_intern(cd_pp_state_t* state, const char* begin, const char* end)
+{
+    assert(state);
+    assert(begin <= end);
+    if(begin == NULL || begin == end) {
+        return NULL;
+    }
+    size_t length = end - begin;
+
+    uint64_t hash = cd_pp_fnv_1a(begin, end);
+    hash = hash ? hash : 1; // hash should never be zero
+    
+    cd_pp_str_item_t* item = (cd_pp_str_item_t*)cd_pp_map_get(&state->str_map, hash);
+    for(cd_pp_str_item_t* i = item; i != NULL; i = i->next) {
+        if(i->length == length) {
+            if(strncmp(i->str, begin, length)==0) {
+                return i->str;
+            }
+        }
+    }
+    
+    cd_pp_str_item_t* new_item = (cd_pp_str_item_t*)cd_pp_arena_alloc(state, &state->str_mem, sizeof(cd_pp_str_item_t) + length + 1);
+    new_item->next = item;
+    new_item->length = length;
+    memcpy(new_item->str, begin, length);
+    new_item->str[length] = '\0';
+    cd_pp_map_insert(&state->str_map, hash, (size_t)new_item);
+    return new_item->str;
+}
+
+void cd_pp_state_free(cd_pp_state_t* state)
+{
+    cd_pp_map_free(&state->str_map);
+    cd_pp_arena_free(&state->str_mem);
+}
+
+
+
+#endif // of CD_PREPROC_IMPLEMENTATION
+
+#ifdef __cplusplus
+}   // extern "C"
+#endif
+
+#endif // of CD_PREPROC_H

--- a/cd_preproc_test.cpp
+++ b/cd_preproc_test.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include <vector>
 #include <string>
+#include <cstdarg>
 #include "cd_preproc.h"
 
 namespace {
@@ -33,7 +34,7 @@ namespace {
         if(strncmp("foo", path.begin, path.end-path.begin)) {
             std::string text = "FOO\n";
             return cd_pp_process(state,
-                                 (cd_pp_strview_t){ text.c_str(), text.c_str() + text.length() },
+                                 cd_pp_strview_t{ text.c_str(), text.c_str() + text.length() },
                                  handle_include,
                                  (void*)43);
         }
@@ -61,12 +62,12 @@ int main(int argc, const char * argv[]) {
         std::vector<std::string> strings;
         for(size_t i=0; i<100; i++) {
             std::string t = "abc" + std::to_string(i);
-            strings_ptr.push_back(cd_pp_str_intern(&pp_state, (cd_pp_strview_t){ t.c_str(), t.c_str()+t.length()}));
+            strings_ptr.push_back(cd_pp_str_intern(&pp_state, cd_pp_strview_t{ t.c_str(), t.c_str()+t.length()}));
             strings.emplace_back(std::move(t));
         }
         for(size_t i=0; i<100; i++) {
             std::string t = "abc" + std::to_string(i) + "abc";
-            strings_ptr.push_back(cd_pp_str_intern(&pp_state, (cd_pp_strview_t){ t.c_str(), t.c_str()+t.length()}));
+            strings_ptr.push_back(cd_pp_str_intern(&pp_state, cd_pp_strview_t{ t.c_str(), t.c_str()+t.length()}));
             strings.emplace_back(std::move(t));
         }
         assert(pp_state.str_map.fill == strings.size());
@@ -75,7 +76,7 @@ int main(int argc, const char * argv[]) {
         }
         for(size_t i=0; i<strings.size(); i++) {
             auto & t = strings[i];
-            auto * p = cd_pp_str_intern(&pp_state, (cd_pp_strview_t){ t.c_str(), t.c_str()+t.length()});
+            auto * p = cd_pp_str_intern(&pp_state, cd_pp_strview_t{ t.c_str(), t.c_str()+t.length()});
             assert(p == strings_ptr[i]);
         }
         assert(pp_state.str_map.fill == strings.size());
@@ -86,7 +87,7 @@ int main(int argc, const char * argv[]) {
         cd_pp_state_t pp_state = new_state();
         std::string text = "FOO BAR\n";
         bool ok = cd_pp_process(&pp_state,
-                             (cd_pp_strview_t){ text.c_str(), text.c_str() + text.length() },
+                             cd_pp_strview_t{ text.c_str(), text.c_str() + text.length() },
                              handle_include,
                              (void*)43);
         assert(ok);

--- a/cd_preproc_test.cpp
+++ b/cd_preproc_test.cpp
@@ -24,6 +24,9 @@ namespace {
         vfprintf(stderr, msg, argp);
         va_end(argp);
         putc('\n', stderr);
+        if(level != CD_PP_LOGLEVEL_DEBUG) {
+            assert(false);
+        }
     }
 
     bool handle_include(void* handler_data,
@@ -108,6 +111,9 @@ int main(int argc, const char * argv[]) {
     //run_test("", "");
     //run_test("FOO BAR\n", "");
     run_test("#if 1\nFOO\n#elif 1\nBAR\n#else\nBAZ\n#endif\n", "");
-    run_test("#define A(p,q,...) B __VA_ARGS__ B B q p    FOO\\  \n  G H\n", "");
+    run_test("#define A B\n"
+             "#define B C\n"
+             "#define C FOO\n"
+             "A\n","");
     return 0;
 }

--- a/cd_preproc_test.cpp
+++ b/cd_preproc_test.cpp
@@ -25,6 +25,22 @@ namespace {
         putc('\n', stderr);
     }
 
+    bool handle_include(void* handler_data,
+                        cd_pp_state_t* state,
+                        cd_pp_strview_t path )
+    {
+        assert(handler_data == (void*)43);
+        if(strncmp("foo", path.begin, path.end-path.begin)) {
+            std::string text = "FOO\n";
+            return cd_pp_process(state,
+                                 (cd_pp_strview_t){ text.c_str(), text.c_str() + text.length() },
+                                 handle_include,
+                                 (void*)43);
+        }
+        return false;
+    }
+
+
     cd_pp_state_t new_state()
     {
         cd_pp_state_t pp_state{0};
@@ -45,12 +61,12 @@ int main(int argc, const char * argv[]) {
         std::vector<std::string> strings;
         for(size_t i=0; i<100; i++) {
             std::string t = "abc" + std::to_string(i);
-            strings_ptr.push_back(cd_pp_str_intern(&pp_state, t.c_str(), t.c_str()+t.length()));
+            strings_ptr.push_back(cd_pp_str_intern(&pp_state, (cd_pp_strview_t){ t.c_str(), t.c_str()+t.length()}));
             strings.emplace_back(std::move(t));
         }
         for(size_t i=0; i<100; i++) {
             std::string t = "abc" + std::to_string(i) + "abc";
-            strings_ptr.push_back(cd_pp_str_intern(&pp_state, t.c_str(), t.c_str()+t.length()));
+            strings_ptr.push_back(cd_pp_str_intern(&pp_state, (cd_pp_strview_t){ t.c_str(), t.c_str()+t.length()}));
             strings.emplace_back(std::move(t));
         }
         assert(pp_state.str_map.fill == strings.size());
@@ -59,13 +75,24 @@ int main(int argc, const char * argv[]) {
         }
         for(size_t i=0; i<strings.size(); i++) {
             auto & t = strings[i];
-            auto * p = cd_pp_str_intern(&pp_state, t.c_str(), t.c_str()+t.length());
+            auto * p = cd_pp_str_intern(&pp_state, (cd_pp_strview_t){ t.c_str(), t.c_str()+t.length()});
             assert(p == strings_ptr[i]);
         }
         assert(pp_state.str_map.fill == strings.size());
         cd_pp_state_free(&pp_state);
     }
 
+    {
+        cd_pp_state_t pp_state = new_state();
+        std::string text = "FOO BAR\n";
+        bool ok = cd_pp_process(&pp_state,
+                             (cd_pp_strview_t){ text.c_str(), text.c_str() + text.length() },
+                             handle_include,
+                             (void*)43);
+        assert(ok);
+        cd_pp_state_free(&pp_state);
+    }
+    
     fprintf(stdout, "woohoo\n");
     return 0;
 }

--- a/cd_preproc_test.cpp
+++ b/cd_preproc_test.cpp
@@ -108,5 +108,6 @@ int main(int argc, const char * argv[]) {
     //run_test("", "");
     //run_test("FOO BAR\n", "");
     run_test("#if 1\nFOO\n#elif 1\nBAR\n#else\nBAZ\n#endif\n", "");
+    run_test("#define A(i) B\n", "");
     return 0;
 }

--- a/cd_preproc_test.cpp
+++ b/cd_preproc_test.cpp
@@ -107,6 +107,6 @@ int main(int argc, const char * argv[]) {
 
     //run_test("", "");
     //run_test("FOO BAR\n", "");
-    run_test("#if 1\nFOO\n#endif\n", "");
+    run_test("#if 1\nFOO\n#elif 1\nBAR\n#else\nBAZ\n#endif\n", "");
     return 0;
 }

--- a/cd_preproc_test.cpp
+++ b/cd_preproc_test.cpp
@@ -105,8 +105,8 @@ int main(int argc, const char * argv[]) {
         cd_pp_state_free(&pp_state);
     }
 
-    run_test("", "");
-    run_test("FOO BAR\n", "");
+    //run_test("", "");
+    //run_test("FOO BAR\n", "");
     run_test("#if 1\nFOO\n#endif\n", "");
     return 0;
 }

--- a/cd_preproc_test.cpp
+++ b/cd_preproc_test.cpp
@@ -7,17 +7,22 @@
 namespace {
 
 
-    void log_func(void* log_data, cd_pp_loglevel_t level, const char* msg)
+    void log_func(void* log_data, cd_pp_loglevel_t level, const char* msg, ...)
     {
         assert(log_data == (void*)42);
         const char * kind = nullptr;
         switch(level) {
-        case CD_PP_LOGLEVEL_DEBUG:      kind = "[debug]"; break;
-        case CD_PP_LOGLEVEL_WARNING:    kind = "[warning]"; break;
-        case CD_PP_LOGLEVEL_ERROR:      kind = "[error]"; break;
+        case CD_PP_LOGLEVEL_DEBUG:  kind = "[debug]"; break;
+        case CD_PP_LOGLEVEL_WARN:   kind = "[warn]";  break;
+        case CD_PP_LOGLEVEL_ERROR:  kind = "[error]"; break;
         default: assert(false); return;
         }
-        fprintf(stderr, "%s %s", kind, msg);
+        fprintf(stderr, "%s ", kind);
+        va_list argp;
+        va_start(argp, msg);
+        vfprintf(stderr, msg, argp);
+        va_end(argp);
+        putc('\n', stderr);
     }
 
     cd_pp_state_t new_state()

--- a/cd_preproc_test.cpp
+++ b/cd_preproc_test.cpp
@@ -108,6 +108,6 @@ int main(int argc, const char * argv[]) {
     //run_test("", "");
     //run_test("FOO BAR\n", "");
     run_test("#if 1\nFOO\n#elif 1\nBAR\n#else\nBAZ\n#endif\n", "");
-    run_test("#define A(i) B\n", "");
+    run_test("#define A B  B B    FOO\\  \n  G H\n", "");
     return 0;
 }

--- a/cd_preproc_test.cpp
+++ b/cd_preproc_test.cpp
@@ -108,6 +108,6 @@ int main(int argc, const char * argv[]) {
     //run_test("", "");
     //run_test("FOO BAR\n", "");
     run_test("#if 1\nFOO\n#elif 1\nBAR\n#else\nBAZ\n#endif\n", "");
-    run_test("#define A B  B B    FOO\\  \n  G H\n", "");
+    run_test("#define A(p,q,...) B __VA_ARGS__ B B q p    FOO\\  \n  G H\n", "");
     return 0;
 }

--- a/cd_preproc_test.cpp
+++ b/cd_preproc_test.cpp
@@ -1,0 +1,66 @@
+#include <cstdio>
+#include <cassert>
+#include <vector>
+#include <string>
+#include "cd_preproc.h"
+
+namespace {
+
+
+    void log_func(void* log_data, cd_pp_loglevel_t level, const char* msg)
+    {
+        assert(log_data == (void*)42);
+        const char * kind = nullptr;
+        switch(level) {
+        case CD_PP_LOGLEVEL_DEBUG:      kind = "[debug]"; break;
+        case CD_PP_LOGLEVEL_WARNING:    kind = "[warning]"; break;
+        case CD_PP_LOGLEVEL_ERROR:      kind = "[error]"; break;
+        default: assert(false); return;
+        }
+        fprintf(stderr, "%s %s", kind, msg);
+    }
+
+    cd_pp_state_t new_state()
+    {
+        cd_pp_state_t pp_state{0};
+        pp_state.log_func = log_func;
+        pp_state.log_data = (void*)42;
+        return pp_state;
+    }
+
+}
+
+
+int main(int argc, const char * argv[]) {
+    
+    {   // Check interning
+        cd_pp_state_t pp_state = new_state();
+
+        std::vector<const char*> strings_ptr;
+        std::vector<std::string> strings;
+        for(size_t i=0; i<100; i++) {
+            std::string t = "abc" + std::to_string(i);
+            strings_ptr.push_back(cd_pp_str_intern(&pp_state, t.c_str(), t.c_str()+t.length()));
+            strings.emplace_back(std::move(t));
+        }
+        for(size_t i=0; i<100; i++) {
+            std::string t = "abc" + std::to_string(i) + "abc";
+            strings_ptr.push_back(cd_pp_str_intern(&pp_state, t.c_str(), t.c_str()+t.length()));
+            strings.emplace_back(std::move(t));
+        }
+        assert(pp_state.str_map.fill == strings.size());
+        for(size_t i=1, n=strings_ptr.size(); i<n; i++) {
+            assert(strings_ptr[i-1] != strings_ptr[i]);
+        }
+        for(size_t i=0; i<strings.size(); i++) {
+            auto & t = strings[i];
+            auto * p = cd_pp_str_intern(&pp_state, t.c_str(), t.c_str()+t.length());
+            assert(p == strings_ptr[i]);
+        }
+        assert(pp_state.str_map.fill == strings.size());
+        cd_pp_state_free(&pp_state);
+    }
+
+    fprintf(stdout, "woohoo\n");
+    return 0;
+}


### PR DESCRIPTION
Creating a basic preprocessor that discards inactive code blocks, does some substitution and determines the set of active symbols.

Intended use-case is to clean up and flatten shader source before sending it to the gfx API, making it easier to debug.

Also, some API implementations counts resource limits somewhat inbetween provided code and active code, so having the set of active symbols in the shaders allows one to only define uniform variables for what is active.